### PR TITLE
Fix fragment linking on sidebar nav

### DIFF
--- a/doc/ldoc.ltp
+++ b/doc/ldoc.ltp
@@ -116,7 +116,7 @@
     <h4>Contents of <strong>$(display_name(module))</strong></h4>
     <ul class="nav">
 > for kind,items in module.kinds() do
-    <li class="nav-item"><a href="#$(kind)"><span class="fragment-hashtag">#</span> $(kind)</a></li>
+    <li class="nav-item"><a href="#$(no_spaces(kind))"><span class="fragment-hashtag">#</span> $(kind)</a></li>
 > end
     </ul>
     </li>


### PR DESCRIPTION
In Entity module, there is a section called "Functions that raise events". Fix fragment linking to the section when clicking the fragment link from the sidebar nav.